### PR TITLE
escape input, fix xss vuln

### DIFF
--- a/client/js/ui.js
+++ b/client/js/ui.js
@@ -44,7 +44,7 @@ if (Meteor.isClient) {
       $('#messages li').slice(0,buffer).remove();
     }
 
-    $('#messages').append('<li>' + msg.from + ': ' + msg.text + '</li>');
+    $('#messages').append($('<li>').text(msg.from + ': ' + msg.text));
     $('#messages').scrollTop( $('#messages').prop("scrollHeight") );
   };
 


### PR DESCRIPTION
Uses JQuery's `.text()` method to escape input instead of allowing any input string to render
